### PR TITLE
reset var

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ module.exports = postcss.plugin("postcss-animation", function () {
   }
 
   return function (css) {
+
+    hasKeyframes = [];
+
     css.walkDecls("animation-name", function(decl) {
       var thisRule = decl.parent;
       var value = decl.value;


### PR DESCRIPTION
Fix problem when using gulp watch. Keyframes was added on first run and not after. We just need to reset the var.